### PR TITLE
Cleanup Github Actions: use debug tags for master auto-builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up env vars 
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ::set-env name=TAGS::"$(date +%Y%m%d).build-$GITHUB_RUN_NUMBER"
+          echo ::set-env name=TAGS::"$(date +%Y%m%d).debug-$GITHUB_RUN_NUMBER"
      
       - name: Set up env vars for release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Now, master is pushed with tags like `20200721.4`, which is very similar to release tag `20200721`. Changing this to `20200721.debug-4`